### PR TITLE
Update progress_indicator.dart

### DIFF
--- a/packages/flutter/lib/src/material/progress_indicator.dart
+++ b/packages/flutter/lib/src/material/progress_indicator.dart
@@ -705,7 +705,14 @@ class _CircularProgressIndicatorState extends State<CircularProgressIndicator> w
 
   Widget _buildCupertinoIndicator(BuildContext context) {
     final Color? tickColor = widget.backgroundColor;
-    return CupertinoActivityIndicator(key: widget.key, color: tickColor);
+    final double? val = widget.value;
+
+    if (val == null) {
+      return CupertinoActivityIndicator(key: widget.key, color: tickColor);
+    }
+
+    return CupertinoActivityIndicator.partiallyRevealed(
+        key: widget.key, color: tickColor, progress: val);
   }
 
   Widget _buildMaterialIndicator(BuildContext context, double headValue, double tailValue, double offsetValue, double rotationValue) {


### PR DESCRIPTION
resolved issue of cicularactivityindicator

this commit is regarding CircularProgressIndicator.adaptive is always indeterminate on Darwin #140574 as the code has been replaced to check whether the value is null or not if the value is not null then we will use partiallyrevealed else the default CupertinoActivityindicator

